### PR TITLE
Support for new VOICEVOX version in the `synthesis` method

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,7 +6,7 @@ use voicevox_client::Client;
 async fn main() -> Result<()> {
     let client = Client::new("http://localhost:50021".to_string(), None);
     let audio_query = client.create_audio_query("こんにちは", 1, None).await?;
-    let audio = audio_query.synthesis(1).await?;
+    let audio = audio_query.synthesis(1, true).await?;
     let mut file = File::create("examples/hello.wav").unwrap();
     file.write_all(&audio).unwrap();
     Ok(())

--- a/src/audio_query.rs
+++ b/src/audio_query.rs
@@ -15,10 +15,18 @@ impl AudioQuery {
         }
     }
 
-    pub async fn synthesis(&self, speaker: i32) -> Result<Bytes> {
+    pub async fn synthesis(
+        &self,
+        speaker: i32,
+        enable_interrogative_upspeak: bool,
+    ) -> Result<Bytes> {
         let data = self
             .restapi
-            .synthesis(&self.audio_query, speaker.to_string().as_str())
+            .synthesis(
+                &self.audio_query,
+                speaker.to_string().as_str(),
+                enable_interrogative_upspeak,
+            )
             .await?;
         Ok(data)
     }

--- a/src/restapi.rs
+++ b/src/restapi.rs
@@ -45,11 +45,17 @@ impl RestAPI {
         Ok(data)
     }
 
-    pub async fn synthesis(&self, audio_query: &AudioQueryType, speaker: &str) -> Result<Bytes> {
+    pub async fn synthesis(
+        &self,
+        audio_query: &AudioQueryType,
+        speaker: &str,
+        enable_interrogative_upspeak: bool,
+    ) -> Result<Bytes> {
         let data = self
             .request("POST", "/synthesis")
             .json(audio_query)
             .query(&[("speaker", speaker)])
+            .query(&[("enable_interrogative_upspeak", enable_interrogative_upspeak)])
             .send()
             .await?
             .bytes()

--- a/src/types/audio_query.rs
+++ b/src/types/audio_query.rs
@@ -37,6 +37,10 @@ pub struct AudioQueryType {
     pre_phoneme_length: f32,
     #[serde(rename = "postPhonemeLength")]
     post_phoneme_length: f32,
+    #[serde(rename = "pauseLength")]
+    pause_length: Option<f32>,
+    #[serde(rename = "pauseLengthScale")]
+    pause_length_scale: f32,
     #[serde(rename = "outputSamplingRate")]
     output_sampling_rate: i32,
     #[serde(rename = "outputStereo")]


### PR DESCRIPTION
Currently, newer versions of VOICEVOX generate an `Internal Server Error` in the `synthesis` method.
Therefore, I added the `pauseLength` and `pauseLengthScale` parameters.

Thanks

## Execution Environment
docker image: voicevox/voicevox_engine:cpu-ubuntu20.04-latest
rustc: 1.78.0